### PR TITLE
Add Clone impl for (Weak)MessageChannel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtra"
-version = "0.4.2"
+version = "0.4.3"
 description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
 edition = "2018"

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -208,6 +208,8 @@ pub(crate) trait AddressEnvelope<M: Message>:
 
     /// It is an error for this method to be called on an already weak address
     fn downgrade(&self) -> Box<dyn AddressEnvelope<M>>;
+
+    fn dup(&self) -> Box<dyn AddressEnvelope<M>>;
 }
 
 impl<A, M> AddressEnvelope<M> for Address<A>
@@ -230,6 +232,10 @@ where
     fn downgrade(&self) -> Box<dyn AddressEnvelope<M>> {
         Box::new(Address::downgrade(self))
     }
+
+    fn dup(&self) -> Box<dyn AddressEnvelope<M>> {
+        Box::new(self.clone())
+    }
 }
 
 impl<A, M> AddressEnvelope<M> for WeakAddress<A>
@@ -251,5 +257,9 @@ where
 
     fn downgrade(&self) -> Box<dyn AddressEnvelope<M>> {
         unimplemented!()
+    }
+
+    fn dup(&self) -> Box<dyn AddressEnvelope<M>> {
+        Box::new(self.clone())
     }
 }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -188,6 +188,14 @@ impl<M: Message> Sink<M> for MessageChannel<M> {
     }
 }
 
+impl<M: Message> Clone for MessageChannel<M> {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address.dup(),
+        }
+    }
+}
+
 /// A message channel is a channel through which you can send only one kind of message, but to
 /// any actor that can handle it. It is like [`Address`](struct.Address.html), but associated with
 /// the message type rather than the actor type. Any existing `WeakMessageChannel`s will *not* prevent the
@@ -259,5 +267,13 @@ impl<M: Message> Sink<M> for WeakMessageChannel<M> {
 
     fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Pin::new(&mut self.get_mut().address).poll_close(ctx)
+    }
+}
+
+impl<M: Message> Clone for WeakMessageChannel<M> {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address.dup(),
+        }
     }
 }


### PR DESCRIPTION
`MessageChannel` and `WeakMessageChannel` can now be cloned like `Address`.

The PR is based on `v0.4.2` of the crate since `v0.5` seems to still be undergoing development.